### PR TITLE
Add the option to put the compressed files in a dedicated directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ module.exports = {
 }
 ```
 
+You can even place all the brotli-compressed files (only the brotli ones, the uncompressed ones will
+be saved in the `public` directory as usual) in a dedicated directory (ex. `public/brotli`):
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-plugin-brotli',
+      options: {
+        path: 'brotli'
+      }
+    }
+  ]
+}
+```
+
 ## Maintainers
 
 Osmond van Hemert


### PR DESCRIPTION
The devops I work with asked me to put the brotli-compressed files in a dedicated directory.
Our need was to serve the static files with CloudFront, using S3 as the origin (in a transparently way from a front-end perspective). The only way to do that is with a specific path.

Since we added the brotli-compressed version of the files we had to disable the automatic compression (gzip) and so I had to do the same thing for the gzip-compressed files. That's why I'm going to open the same PR for the `gatsby-plugin-zopfli` plugin too.