### PR TITLE
Use max brotli quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ module.exports = {
 }
 ```
 
-Currently, files are compressed using the highest level of compression supported by brotli.
-
 By default, only `.css` and `.js` files are compressed, but you can override this with the `extensions` option.
 
 ```javascript
@@ -59,6 +57,21 @@ module.exports = {
       resolve: 'gatsby-plugin-brotli',
       options: {
         extensions: ['css', 'html', 'js', 'svg']
+      }
+    }
+  ]
+}
+```
+
+By default, files are compressed using the highest level of compression supported by brotli, but you can override this with the `level` option.
+
+```javascript
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-plugin-brotli',
+      options: {
+        level: 4
       }
     }
   ]

--- a/src/brotli-plugin.js
+++ b/src/brotli-plugin.js
@@ -3,13 +3,15 @@
 const glob = require('glob')
 const path = require('path')
 const util = require('util')
+const zlib = require('zlib')
 
 const Piscina = require('piscina')
 
 const defaultOptions = {
   cwd: path.join(process.cwd(), 'public'),
   extensions: ['css', 'js'],
-  path: ''
+  path: '',
+  level: zlib.constants.BROTLI_MAX_QUALITY
 }
 
 const globAsync = util.promisify(glob)
@@ -24,7 +26,8 @@ async function onPostBuild ({ reporter }, pluginOptions) {
   const files = globResult.map(res => {
     return {
       from: path.join(options.cwd, res),
-      to: path.join(options.cwd, options.path, `${res}.br`)
+      to: path.join(options.cwd, options.path, `${res}.br`),
+      level: options.level
     }
   })
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -9,14 +9,14 @@ const zlib = require('zlib')
 
 const pipelineAsync = util.promisify(pipeline)
 
-async function brotliCompressFile (from, to) {
+async function brotliCompressFile (from, to, level) {
   const toDir = path.dirname(to)
   await mkdirp(toDir)
   await pipelineAsync(
     fs.createReadStream(from),
     zlib.createBrotliCompress({
       params: {
-        [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
+        [zlib.constants.BROTLI_PARAM_QUALITY]: level,
         [zlib.constants.BROTLI_PARAM_SIZE_HINT]: fs.statSync(from).size
       }
     }),
@@ -24,6 +24,6 @@ async function brotliCompressFile (from, to) {
   )
 }
 
-module.exports = async function ({ from, to }) {
-  return brotliCompressFile(from, to)
+module.exports = async function ({ from, to, level }) {
+  return brotliCompressFile(from, to, level)
 }

--- a/test/brotli-plugin.test.js
+++ b/test/brotli-plugin.test.js
@@ -37,6 +37,19 @@ test('compress only single extension', t => {
     .finally(() => t.end())
 })
 
+test('compress with custom level', t => {
+  const cwd = t.testdir(TEST_DIR)
+  const args = { reporter: { info: sinon.fake() } }
+  tested.onPostBuild(args, { cwd, level: 1 })
+    .then(res => {
+      t.ok(fs.existsSync(path.join(cwd, 'test.css.br')))
+      t.ok(fs.existsSync(path.join(cwd, 'test.js.br')))
+      t.notOk(fs.existsSync(path.join(cwd, 'test.html.br')))
+    })
+    .catch(err => t.fail(err))
+    .finally(() => t.end())
+})
+
 test('compress to another folder', t => {
   const cwd = t.testdir(TEST_DIR)
   const dir = 'brotli'

--- a/test/worker.test.js
+++ b/test/worker.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const test = require('tap').test
+const zlib = require('zlib')
 
 const tested = require('../src/worker')
 
@@ -12,8 +13,9 @@ test('brotli compresses test file', t => {
   })
   const from = path.join(cwd, 'public/test.js')
   const to = path.join(cwd, 'public/test.js.br')
+  const level = zlib.constants.BROTLI_MAX_QUALITY
 
-  tested({ from, to })
+  tested({ from, to, level })
     .then(res => {
       const compressed = path.join(cwd, 'public/test.js.br')
       t.ok(fs.existsSync(compressed))


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.
-->

Since we are compressing ahead-of-time, it makes sense to compress using maximum quality. Allow users to override the level in the configuration, if needed.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
  - Covered by existing tests
- [x] documentation is changed or added
- [x] commit message and code follows *Code Of Conduct*
